### PR TITLE
Support null values in database response

### DIFF
--- a/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/db/Database.kt
+++ b/core/src/jvmMain/kotlin/de/p7s1/qa/sevenfacette/db/Database.kt
@@ -56,8 +56,8 @@ class Database(
      * @return [result] as List<Map<String, Any>> or an empty list
      */
     @Deprecated(message = "This function will be deleted in version 2.0.0")
-    fun executeStatements(dbStatements: DbStatements) : List<Map<String, Any>>? {
-        var result: List<Map<String, Any>> = mutableListOf()
+    fun executeStatements(dbStatements: DbStatements) : List<Map<String, Any?>>? {
+        var result: List<Map<String, Any?>> = mutableListOf()
         try {
             openConnection().use { conn ->
                 dbStatements.list.forEach(Consumer {
@@ -233,19 +233,15 @@ class Database(
      * @return [result]
      */
     @Deprecated(message = "This function will be deleted in version 2.0.0")
-    private fun convertResultSetToList(rs: ResultSet) : List<Map<String, Any>> {
+    private fun convertResultSetToList(rs: ResultSet) : List<Map<String, Any?>> {
         return try {
-            val result: MutableList<Map<String, Any>> = mutableListOf()
+            val result: MutableList<Map<String, Any?>> = mutableListOf()
             val md = rs.metaData
             val columns = md.columnCount
             while (rs.next()) {
-                val row: MutableMap<String, Any> = HashMap(columns)
+                val row: MutableMap<String, Any?> = HashMap(columns)
                 for (i in 1..columns) {
-                    if (rs.getObject(i) == null) {
-                        row[md.getColumnName(i)] = emptyValue
-                    } else {
-                        row[md.getColumnName(i)] = rs.getObject(i)
-                    }
+                    row[md.getColumnName(i)] = rs.getObject(i)
                 }
                 result.add(row)
             }


### PR DESCRIPTION
When executing a sql statement, each record of the result
is converted into a map. This map does not support null values,
instead it uses "NULL" strings, which cannot be handled the
right way by the caller.

To avoid this issue, the map now supports null values.
In this way the client is able to distinguish between strings
and columns without value.